### PR TITLE
Use absolute path to settings file

### DIFF
--- a/vroxy.py
+++ b/vroxy.py
@@ -61,7 +61,7 @@ pool = PoolCount()
 routes = web.RouteTableDef()
 
 config = ConfigParser({"server": {"host": "localhost", "port": "8008"}})
-if path.isfile("./settings.ini"): config.read("./settings.ini")
+if path.isfile(path.join(path.dirname(__file__), "settings.ini")): config.read(path.join(path.dirname(__file__), "settings.ini"))
 
 mode_map = {
     # default


### PR DESCRIPTION
Makes it so config tries to read from beside where the `vroxy.py` file is located as opposed to the working dir of the active shell which may not always be the same depending on how it's ran.