### PR TITLE
allow environment variable config

### DIFF
--- a/vroxy.py
+++ b/vroxy.py
@@ -63,7 +63,7 @@ routes = web.RouteTableDef()
 
 config = ConfigParser()
 config["server"] = {
-    "host": os.getenv("VROXY_HOST", "localhost"),
+    "host": os.getenv("VROXY_HOST", "0.0.0.0"),
     "port": os.getenv("PORT", "8008"),
 }
 if path.isfile(path.join(path.dirname(__file__), "settings.ini")): config.read(path.join(path.dirname(__file__), "settings.ini"))

--- a/vroxy.py
+++ b/vroxy.py
@@ -5,6 +5,7 @@ import time
 import re
 import random
 from os import path
+import os
 from urllib.parse import urlparse
 
 from aiohttp import web
@@ -60,7 +61,11 @@ pool_max = 10
 pool = PoolCount()
 routes = web.RouteTableDef()
 
-config = ConfigParser({"server": {"host": "localhost", "port": "8008"}})
+config = ConfigParser()
+config["server"] = {
+    "host": os.getenv("VROXY_HOST", "localhost"),
+    "port": os.getenv("VROXY_PORT", "8008"),
+}
 if path.isfile("./settings.ini"): config.read("./settings.ini")
 
 mode_map = {

--- a/vroxy.py
+++ b/vroxy.py
@@ -64,7 +64,7 @@ routes = web.RouteTableDef()
 config = ConfigParser()
 config["server"] = {
     "host": os.getenv("VROXY_HOST", "localhost"),
-    "port": os.getenv("VROXY_PORT", "8008"),
+    "port": os.getenv("PORT", "8008"),
 }
 if path.isfile(path.join(path.dirname(__file__), "settings.ini")): config.read(path.join(path.dirname(__file__), "settings.ini"))
 


### PR DESCRIPTION
In containerized environments it is useful to be able to config via environment variables rather than mounting a config file

Cloud run: https://cloud.google.com/run/docs/container-contract#:~:text=Cloud%20Run%20injects%20the%20PORT,It%20defaults%20to%208080%20.