### PR TITLE
Avoid bare except

### DIFF
--- a/vroxy.py
+++ b/vroxy.py
@@ -36,6 +36,7 @@ class YTDLProxy(web.View):
 
     async def process(self):
         url = None
+        res = web.Response(status=500)
         try:
             url = await resolveUrl(self.request.query)
             res = web.Response(status=307, headers={"Location": url})
@@ -53,7 +54,7 @@ class YTDLProxy(web.View):
             res = web.Response(status=410)
         except Error429TooManyRequests:
             res = web.Response(status=429)
-        except:
+        except Exception:
             res = web.Response(status=500)
         return res
 


### PR DESCRIPTION
https://peps.python.org/pep-0008/#:~:text=A%20bare%20except%3A%20clause%20will%20catch%20SystemExit%20and%20KeyboardInterrupt%20exceptions

>A bare except: clause will catch SystemExit and KeyboardInterrupt exceptions, making it harder to interrupt a program with Control-C, and can disguise other problems. If you want to catch all exceptions that signal program errors, use except Exception: (bare except is equivalent to except BaseException:).