### PR TITLE
Adds e2e for vroxy_install_dev.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,35 @@ services:
       - VROXY_AUTH_TOKENS=abc,123
     profiles:
       - donotstart
+  vroxy-install-e2e.test:
+    image: debian:bullseye
+    command: tail -F /dev/null
+    environment:
+      - CI=true
+      - DEBIAN_FRONTEND=noninteractive
+      - domain=vroxy-install-e2e.test
+      - acme_server=https://pebble:14000/dir
+    working_dir: /vroxy
+    volumes:
+      - .:/vroxy
+    profiles:
+      - donotstart
+  pebble:
+    image: letsencrypt/pebble:latest
+    command: pebble -config /test/config/pebble-config.json -strict -dnsserver 10.30.50.3:8053
+    # ports:
+    #   - 14000:14000  # HTTPS ACME API
+    #   - 15000:15000  # HTTPS Management API
+    environment:
+      - PEBBLE_VA_ALWAYS_VALID=1
+    profiles:
+      - vroxy_install
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "--no-check-certificate", "https://localhost:14000/dir"]
+      interval: 5s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
   dev:
     build:
       context: .

--- a/tests_e2e/test_deb_bootstrap.sh
+++ b/tests_e2e/test_deb_bootstrap.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ "$CI" != "true" ]; then
+    echo "Cowardly refusing to run bootstrap on what looks like a non-CI environment."
+    echo "This bootstrap is only intended for ephemeral CI machines."
+    echo "Running this on a real machine will make it insecure."
+    exit 1
+fi
+
+set -x
+
+apt-get update
+
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cron \
+    curl \
+    git
+
+curl -o /usr/local/share/ca-certificates/pebble.minica.crt https://raw.githubusercontent.com/letsencrypt/pebble/main/test/certs/pebble.minica.pem
+
+update-ca-certificates

--- a/tests_e2e/test_deb_setup.sh
+++ b/tests_e2e/test_deb_setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+set -ex
+
+cleanup() {
+  docker compose rm -fsv pebble vroxy-install-e2e.test
+}
+
+cleanup
+
+# trap cleanup EXIT
+
+docker compose up -d --wait pebble
+docker compose up -d vroxy-install-e2e.test
+
+DRUN="docker compose exec vroxy-install-e2e.test"
+
+$DRUN ./tests_e2e/test_deb_bootstrap.sh
+$DRUN ./vroxy_install_deb.sh
+sleep 15
+$DRUN curl -f localhost:8420/healthz

--- a/vroxy_reload.sh
+++ b/vroxy_reload.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(pwd)
 echo "Stopping Vroxy service"
 tmux kill-session -t vroxy
 echo "Checking for latest Vroxy updates"
-git pull
+git pull --ff-only
 echo "Starting Vroxy service from $SCRIPT_DIR"
 tmux new-session -d -s vroxy \; send-keys "python3 $SCRIPT_DIR/vroxy.py" Enter
 echo "Vroxy service successfully started in a tmux session"


### PR DESCRIPTION
Not working yet.

Essentially starts a blank debian container, runs the install script, checks that vroxy is up
Adds pebble as a bogus ACME client to test certbot setup